### PR TITLE
initial support for optional display fields (do not show for now)

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -318,6 +318,9 @@ function mergeRepeatedFields( hits ) {
       if (field.value === "") {
         return
       }
+      if (field.display == "optional") {
+        return
+      }
       if (field.name == "preview_url") {
         hit.previewURL = field.value
         return


### PR DESCRIPTION
This simply ignores fields with "display": "optional".  Later on, display of "optional" fields will be controlled by user preference.