### PR TITLE
Updated pattern for /catalog catch-all route to catch more.

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -95,7 +95,7 @@ const router = new Router({
       },
       {
          // this is a catchall route for catalog queries from external search boxes
-         path: '/catalog',
+         path: '/catalog*',
          beforeEnter: (to, _from, next) => {
             let field = to.query.search_field
             if ( field == "journal") {


### PR DESCRIPTION
https://jira.lib.virginia.edu/browse/VIRGONEW-1548

I think this might fix other links that have /catalog?something, but having not tested it locally, I'm using a PR for this one character change.